### PR TITLE
Fix the performance issue in the ternary operation

### DIFF
--- a/src/main/java/com/bladecoder/ink/runtime/Story.java
+++ b/src/main/java/com/bladecoder/ink/runtime/Story.java
@@ -134,9 +134,8 @@ public class Story extends RTObject implements VariablesState.VariableChanged {
 			listsDefinitions = Json.jTokenToListDefinitions(listDefsObj);
 		}
 
-		mainContentContainer = Json.jTokenToRuntimeObject(rootToken) instanceof Container
-				? (Container) Json.jTokenToRuntimeObject(rootToken)
-				: null;
+		RTObject runtimeObject = Json.jTokenToRuntimeObject(rootToken);
+		mainContentContainer = runtimeObject instanceof Container ? (Container) runtimeObject : null;
 
 		resetState();
 	}


### PR DESCRIPTION
The jTokenToRuntimeObject is expensive, having the ternary operation will lead to twice invocation on the method