### PR TITLE
Ensure Android compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 # Matching Ink v1.0.0
-version=1.0.0-micabytes.1
+version=1.0.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 # Matching Ink v1.0.0
-version=1.0.0
+version=1.0.0-micabytes.1
 

--- a/src/main/java/com/bladecoder/ink/runtime/Flow.java
+++ b/src/main/java/com/bladecoder/ink/runtime/Flow.java
@@ -30,7 +30,13 @@ public class Flow {
 		// choiceThreads is optional
 		Object jChoiceThreadsObj;
 
-		jChoiceThreadsObj = jObject.getOrDefault("choiceThreads", null);
+		// This does not work in Android with SDK < 24
+		//jChoiceThreadsObj = jObject.getOrDefault("choiceThreads", null);
+		if (jObject.containsKey("choiceThreads")) {
+			jChoiceThreadsObj = jObject.get("choiceThreads");
+		} else {
+			jChoiceThreadsObj = null;
+		}
 
 		loadFlowChoiceThreads((HashMap<String, Object>) jChoiceThreadsObj, story);
 	}


### PR DESCRIPTION
getOrDefault(..) is not available in Android versions earlier than SDK 24, which results in blade-ink crashing in a (as yet) significant number of Android devices. This commit fixes that problem and ensures blade-ink still works on older Android devices.